### PR TITLE
Label Context 생성 및 전체 라벨 목록 조회 API 구현

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,27 +1,28 @@
-import React,{useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import IssuePage from './pages/IssuePage';
+import NewIssuePage from './pages/NewIssuePage';
 import UserPage from './pages/UserPage';
 import Cookie from './util/cookie'
 import LocalStorage from './util/localStorage'
 const App = () => {
   let [userState, setUserState] = useState({
-    user : '',
-    token : '',
-    authenticated : false
+    user: '',
+    token: '',
+    authenticated: false
   })
 
-  const isAuthenticated = () =>{
+  const isAuthenticated = () => {
     let userObj = {
       user,
       token,
-      authenticated : true
+      authenticated: true
     };
     const user = LocalStorage.getItem('user') || undefined
     const token = LocalStorage.getItem('token') || undefined
-    if(typeof user==="undefined"){
+    if (typeof user === "undefined") {
       let cookie = document.cookie;
-      userObj = Cookie.hasCookie(userObj,cookie)
+      userObj = Cookie.hasCookie(userObj, cookie)
     }
 
     // Todo : userState 관리
@@ -33,6 +34,7 @@ const App = () => {
     <Switch>
       <Route exact path="/" component={IssuePage} />
       <Route path="/login" component={UserPage} />
+      <Route path="/new" component={NewIssuePage} />
       <Route
         render={({ location }) => (
           <div>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,16 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { Switch, Route } from 'react-router-dom';
-import IssuePage from './pages/IssuePage';
-import NewIssuePage from './pages/NewIssuePage';
-import UserPage from './pages/UserPage';
-import Cookie from './util/cookie'
-import LocalStorage from './util/localStorage'
+import IssuePage from '@pages/IssuePage';
+import NewIssuePage from '@pages/NewIssuePage';
+import UserPage from '@pages/UserPage';
+import Cookie from '@util/cookie';
+import LocalStorage from '@util/localStorage';
+
 const App = () => {
-  let [userState, setUserState] = useState({
+  const [userState, setUserState] = useState({
     user: '',
     token: '',
     authenticated: false
-  })
+  });
 
   const isAuthenticated = () => {
     let userObj = {
@@ -18,18 +19,20 @@ const App = () => {
       token,
       authenticated: true
     };
-    const user = LocalStorage.getItem('user') || undefined
-    const token = LocalStorage.getItem('token') || undefined
+    const user = LocalStorage.getItem('user') || undefined;
+    const token = LocalStorage.getItem('token') || undefined;
+
     if (typeof user === "undefined") {
-      let cookie = document.cookie;
-      userObj = Cookie.hasCookie(userObj, cookie)
+      const cookie = document.cookie;
+      userObj = Cookie.hasCookie(userObj, cookie);
     }
 
     // Todo : userState 관리
     //setUserState(userObj)
   }
 
-  isAuthenticated()
+  isAuthenticated();
+
   return (
     <Switch>
       <Route exact path="/" component={IssuePage} />

--- a/client/src/api/label.js
+++ b/client/src/api/label.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export async function getLabels() {
+  const response = await axios.get('/api/label/list');
+  return response.data;
+}

--- a/client/src/components/issues/IssueList/List/Issue/index.js
+++ b/client/src/components/issues/IssueList/List/Issue/index.js
@@ -9,7 +9,6 @@ import {
 } from './style';
 
 function Issue({ issue }) {
-  console.log('issue :>> ', issue);
   return (
     <IssueWrapper>
       <input className="issue-checkbox" type="checkbox" />

--- a/client/src/components/issues/IssueList/List/index.js
+++ b/client/src/components/issues/IssueList/List/index.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import Issue from './Issue';
-// import { useIssuesState, useIssuesDispatch, getIssues } from '../../../../contexts/IssuesContext';
-import { useIssuesState, useIssuesDispatch, getIssues } from '../../../../contexts/IssuesContext';
+import { useIssuesState, useIssuesDispatch, getIssues } from '@contexts/IssuesContext';
 
 function List() {
   const state = useIssuesState();

--- a/client/src/components/label/index.js
+++ b/client/src/components/label/index.js
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import { useLabelState, useLabelDispatch, getLabels } from '../../contexts/LabelContext';
+
+function Label() {
+  const state = useLabelState();
+  const dispatch = useLabelDispatch();
+
+  const { data: labels, loading, error } = state.labels;
+
+  const fetchData = () => {
+    getLabels(dispatch);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [dispatch]);
+  console.log('labels :>> ', labels);
+
+  if (loading) return <div> 로딩중.. </div>;
+  if (error) return <div> 에러가 발생했습니다 </div>;
+  if (!labels) return <button onClick={fetchData}> 불러오기 </button>;
+
+  return (
+    <>
+      {labels.map((label) => (
+        <>
+          <div>{label.name}</div>
+          <div>{label.desc}</div>
+          <div>{label.color}</div>
+        </>
+      ))}
+    </>
+  );
+}
+
+export default Label;

--- a/client/src/components/label/index.js
+++ b/client/src/components/label/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useLabelState, useLabelDispatch, getLabels } from '../../contexts/LabelContext';
+import { useLabelState, useLabelDispatch, getLabels } from '@contexts/LabelContext';
 
 function Label() {
   const state = useLabelState();

--- a/client/src/components/user/UserLogin/index.js
+++ b/client/src/components/user/UserLogin/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import S from './style';
 import { MarkGithubIcon } from '@primer/octicons-react';
-import Logo from '../../../../public/images/issuelogo.png';
-import LocalStorage from '../../../util/localStorage';
-import Cookie from '../../../util/cookie';
+import Logo from '@images/issuelogo.png';
+import LocalStorage from '@util/localStorage';
+import Cookie from '@util/cookie';
+
 function UserLogin() {
   const logoutHandler = () => {
     LocalStorage.clear();

--- a/client/src/contexts/IssuesContext.js
+++ b/client/src/contexts/IssuesContext.js
@@ -1,5 +1,5 @@
 import React, { useReducer, createContext, useContext } from 'react';
-import * as api from '../api/issue';
+import * as api from '@api/issue';
 
 // IssuesContext에서 사용할 기본 상태
 const initialState = {

--- a/client/src/contexts/LabelContext.js
+++ b/client/src/contexts/LabelContext.js
@@ -1,5 +1,5 @@
 import React, { useReducer, createContext, useContext } from 'react';
-import * as api from '../api/label';
+import * as api from '@api/label';
 
 const initialState = {
   labels: {

--- a/client/src/contexts/LabelContext.js
+++ b/client/src/contexts/LabelContext.js
@@ -1,0 +1,91 @@
+import React, { useReducer, createContext, useContext } from 'react';
+import * as api from '../api/label';
+
+const initialState = {
+  labels: {
+    loading: false,
+    data: null,
+    error: null,
+  },
+};
+
+const loadingState = {
+  loading: true,
+  data: null,
+  error: null,
+};
+
+const success = (data) => ({
+  loading: false,
+  data,
+  error: null,
+});
+
+const error = (err) => ({
+  loading: true,
+  data: null,
+  err,
+});
+
+function labelReducer(state, action) {
+  switch (action.type) {
+    case 'GET_LABELS':
+      return {
+        ...state,
+        labels: loadingState,
+      };
+    case 'GET_LABELS_SUCCESS':
+      return {
+        ...state,
+        labels: success(action.data),
+      };
+    case 'GET_LABELS_ERROR':
+      return {
+        ...state,
+        labels: error(action.error),
+      };
+    default:
+      return state;
+  }
+}
+
+const LabelStateContext = createContext(null);
+const LabelDispatchContext = createContext(null);
+
+export function LabelProvider({ children }) {
+  const [state, dispatch] = useReducer(labelReducer, initialState);
+
+  return (
+    <LabelStateContext.Provider value={state}>
+      <LabelDispatchContext.Provider value={dispatch}>
+        {children}
+      </LabelDispatchContext.Provider>
+    </LabelStateContext.Provider>
+  );
+}
+
+export function useLabelState() {
+  const state = useContext(LabelStateContext);
+  if (!state) {
+    throw new Error('Cannot find LabelProvider!');
+  }
+  return state;
+}
+
+export function useLabelDispatch() {
+  const dispatch = useContext(LabelDispatchContext);
+  if (!dispatch) {
+    throw new Error('Cannot find LabelProvider!');
+  }
+  return dispatch;
+}
+
+export async function getLabels(dispatch) {
+  dispatch({ type: 'GET_LABELS' });
+  try {
+    const response = await api.getLabels();
+    dispatch({ type: 'GET_LABELS_SUCCESS', data: response.data });
+  } catch (e) {
+    dispatch({ type: 'GET_LABELS_ERROR', error: e });
+  }
+}

--- a/client/src/pages/IssuePage.js
+++ b/client/src/pages/IssuePage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Issues from '../components/issues';
 import 'semantic-ui-css/semantic.min.css';
-import { IssuesProvider } from '../contexts/IssuesContext';
+import { IssuesProvider } from '@contexts/IssuesContext';
 
 function IssuePage() {
   return (

--- a/client/src/pages/NewIssuePage.js
+++ b/client/src/pages/NewIssuePage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Label from '../components/label';
+import { LabelProvider } from '../contexts/LabelContext';
+
+function NewIssuePage() {
+  return (
+    <LabelProvider>
+      <Label />
+    </LabelProvider>
+  )
+}
+
+export default NewIssuePage;

--- a/client/src/pages/NewIssuePage.js
+++ b/client/src/pages/NewIssuePage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Label from '../components/label';
-import { LabelProvider } from '../contexts/LabelContext';
+import { LabelProvider } from '@contexts/LabelContext';
 
 function NewIssuePage() {
   return (

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -26,6 +26,10 @@ module.exports = {
   resolve: {
     alias: {
       '@contexts': path.resolve(__dirname, 'src/contexts'),
+      '@api': path.resolve(__dirname, 'src/api'),
+      '@util': path.resolve(__dirname, 'src/util'),
+      '@pages': path.resolve(__dirname, 'src/pages'),
+      '@images': path.resolve(__dirname, 'public/images'),
     },
     extensions: ['*', '.js', '.jsx'],
   },

--- a/server/routes/label/controller.js
+++ b/server/routes/label/controller.js
@@ -1,7 +1,7 @@
 const labelServices = require('../../services/label');
 
 /*
-    GET /api/issue/label
+    GET /api/label/list
     * 전체 라벨 목록 조회 API
 */
 exports.getLabels = async (req, res, next) => {

--- a/server/routes/label/controller.js
+++ b/server/routes/label/controller.js
@@ -1,0 +1,18 @@
+const labelServices = require('../../services/label');
+
+/*
+    GET /api/issue/label
+    * 전체 라벨 목록 조회 API
+*/
+exports.getLabels = async (req, res, next) => {
+  try {
+    const labels = await labelServices.getLabels();
+
+    res.json({
+      message: '전체 라벨 목록 조회 성공',
+      data: labels,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/server/routes/label/index.js
+++ b/server/routes/label/index.js
@@ -1,10 +1,6 @@
-const express = require('express');
+const router = require('express').Router();
+const controller = require('./controller');
 
-const router = express.Router();
-
-/* GET home page. */
-router.get('/', function (req, res, next) {
-  res.render('index', { title: 'Express' });
-});
+router.get('/list', controller.getLabels);
 
 module.exports = router;

--- a/server/services/db/label.js
+++ b/server/services/db/label.js
@@ -1,0 +1,9 @@
+const { Label } = require('../../models');
+
+exports.selectLabel = async () => {
+  const labels = await Label.findAll({
+    attributes: ['id', 'name', 'desc', 'color'],
+  });
+
+  return labels;
+};

--- a/server/services/label.js
+++ b/server/services/label.js
@@ -1,0 +1,19 @@
+const db = require('./db/label');
+
+exports.getLabels = async () => {
+  const results = await db.selectLabel();
+
+  const data = [];
+
+  for (const result of results) {
+    const label = {};
+    label.id = result.id;
+    label.name = result.name;
+    label.desc = result.desc;
+    label.color = result.color;
+
+    data.push(label);
+  }
+
+  return data;
+};


### PR DESCRIPTION
### 구현한 기능
- 전체 라벨 목록 조회 API 구현
- Label context 구현
- NewIssuePage 생성
- label context 테스트를 위한 Label 컴포넌트 생성 및 context 연동
- alias를 사용해 파일 경로 단축

![image](https://user-images.githubusercontent.com/26537048/97890072-73b95300-1d70-11eb-913c-43c3ed72f7d4.png)
- `/new` 경로로 들어가면 전체 라벨 목록 데이터만 뜨게 해놨습니다,,,
