### PR TITLE
마일스톤 목록, 생성, 수정 페이지 구현

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,7 @@ import UserPage from '@pages/UserPage';
 import LabelPage from '@pages/LabelPage';
 import MilestonePage from '@pages/MilestonePage';
 import NewMilestonePage from '@pages/NewMilestonePage';
+import EditMilestonePage from '@pages/EditMilestonePage';
 import IssueDetailPage from '@pages/IssueDetailPage';
 import { LabelProvider } from '@contexts/LabelContext';
 import { MilestonesProvider } from '@contexts/MilestonesContext';
@@ -28,6 +29,7 @@ const App = () => {
             />
             <Route path="/newIssue" component={NewIssuePage} />
             <Route path="/label" component={LabelPage} />
+            <Route path="/milestone/edit/:id" component={EditMilestonePage} />
             <Route path="/milestone" component={MilestonePage} />
             <Route path="/newMilestone" component={NewMilestonePage} />
             <Route path="/detail/:id" component={IssueDetailPage} />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -30,8 +30,8 @@ const App = () => {
             <Route path="/newIssue" component={NewIssuePage} />
             <Route path="/label" component={LabelPage} />
             <Route path="/milestone/edit/:id" component={EditMilestonePage} />
+            <Route path="/milestone/new" component={NewMilestonePage} />
             <Route path="/milestone" component={MilestonePage} />
-            <Route path="/newMilestone" component={NewMilestonePage} />
             <Route path="/detail/:id" component={IssueDetailPage} />
             <Route
               render={({ location }) => (

--- a/client/src/api/milestone.js
+++ b/client/src/api/milestone.js
@@ -27,4 +27,14 @@ const updateMilestone = async ({ id, title, due_date, desc }) => {
   return response.data;
 };
 
-export { getMilestones, createMilestone, updateMilestone };
+const updateMilestoneStatus = async (params) => {
+  const response = await axios.put(`/api/milestone/${params.id}`, params);
+  return response.data;
+};
+
+export {
+  getMilestones,
+  createMilestone,
+  updateMilestone,
+  updateMilestoneStatus
+};

--- a/client/src/api/milestone.js
+++ b/client/src/api/milestone.js
@@ -16,4 +16,15 @@ const createMilestone = async ({ status, title, due_date, desc }) => {
   return response.data;
 };
 
-export { getMilestones, createMilestone };
+const updateMilestone = async ({ id, title, due_date, desc }) => {
+  let params = {};
+  if (due_date.length === 0 && desc.length === 0) params = { title };
+  else if (due_date.length === 0) params = { title, desc };
+  else if (desc.length === 0) params = { title, due_date };
+  else params = { title, due_date, desc };
+
+  const response = await axios.put(`/api/milestone/${id}`, params);
+  return response.data;
+};
+
+export { getMilestones, createMilestone, updateMilestone };

--- a/client/src/api/milestone.js
+++ b/client/src/api/milestone.js
@@ -32,9 +32,16 @@ const updateMilestoneStatus = async (params) => {
   return response.data;
 };
 
+const deleteMilestone = async ({ id }) => {
+  const response = await axios.delete(`/api/milestone/${id}`);
+  console.log('response :>> ', response);
+  return response.data;
+};
+
 export {
   getMilestones,
   createMilestone,
   updateMilestone,
-  updateMilestoneStatus
+  updateMilestoneStatus,
+  deleteMilestone
 };

--- a/client/src/api/milestone.js
+++ b/client/src/api/milestone.js
@@ -5,4 +5,15 @@ const getMilestones = async () => {
   return response.data;
 };
 
-export { getMilestones };
+const createMilestone = async ({ status, title, due_date, desc }) => {
+  let params = {};
+  if (due_date.length === 0 && desc.length === 0) params = { status, title };
+  else if (due_date.length === 0) params = { status, title, desc };
+  else if (desc.length === 0) params = { status, title, due_date };
+  else params = { status, title, due_date, desc };
+
+  const response = await axios.post('/api/milestone', params);
+  return response.data;
+};
+
+export { getMilestones, createMilestone };

--- a/client/src/components/editMilestone/index.js
+++ b/client/src/components/editMilestone/index.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import BS from '@components/issues/header/buttons/style';
-import Input from '@components/newMilestone/input';
+import { useMilestonesDispatch, updateMilestone } from '@contexts/MilestonesContext';
 import { TagIcon, MilestoneIcon } from '@primer/octicons-react';
+import BS from '@components/issues/header/buttons/style';
+import IS from '@components/newMilestone/input/style';
 import MS from '@components/milestones/header/style';
 import S from './style';
 
@@ -10,6 +11,37 @@ function EditMilestone() {
   const history = useHistory();
   const location = useLocation();
   const { milestone } = location.state;
+  const dispatch = useMilestonesDispatch();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleTitle = ({ target }) => {
+    setTitle(target.value);
+  };
+
+  const handleDescription = ({ target }) => {
+    setDescription(target.value);
+  };
+
+  const handleCloseClick = () => {
+    /** @todo close버튼 클릭하면 마일스톤 status를 close로 업데이트 */
+  };
+
+  const handleSaveClick = () => {
+    const date = document.querySelector('.edit-date').value;
+
+    if (title.length === 0) return;
+
+    updateMilestone(dispatch, {
+      id: milestone.id,
+      title,
+      due_date: date,
+      desc: description
+    });
+
+    history.push('/milestone');
+  };
 
   return (
     <S.EditMilestoneWrapper>
@@ -25,11 +57,33 @@ function EditMilestone() {
           </MS.MilestonesButton>
         </S.LabelMilestone>
       </S.Header>
-      <Input />
+      <IS.InputWrapper>
+        <IS.Title>Title</IS.Title>
+        <IS.InputTitle
+          className='form-control'
+          placeholder='Title'
+          type='text'
+          defaultValue={milestone.title}
+          onChange={handleTitle}
+        />
+        <IS.Title>Due Date (optional)</IS.Title>
+        <IS.InputDate
+          className='form-control edit-date'
+          type='date'
+          defaultValue={milestone.due_date}
+        />
+        <IS.Title>Description (optional)</IS.Title>
+        <IS.InputDescription
+          className='form-control'
+          type='text'
+          defaultValue={milestone.desc}
+          onChange={handleDescription}
+        />
+      </IS.InputWrapper>
       <S.ButtonWrapper>
-        <S.CancelButton>Cancel</S.CancelButton>
-        <S.CancelButton>Close milestone</S.CancelButton>
-        <BS.NewIssueButton>Create milestone</BS.NewIssueButton>
+        <S.CancelButton onClick={() => history.push('/milestone')}>Cancel</S.CancelButton>
+        <S.CancelButton onClick={handleCloseClick}>Close milestone</S.CancelButton>
+        <BS.NewIssueButton onClick={handleSaveClick}>Save Changes</BS.NewIssueButton>
       </S.ButtonWrapper>
     </S.EditMilestoneWrapper>
   );

--- a/client/src/components/editMilestone/index.js
+++ b/client/src/components/editMilestone/index.js
@@ -28,12 +28,10 @@ function EditMilestone() {
     setDescription(target.value);
   };
 
-  const handleCloseClick = () => {
-    if (milestone.status === 'closed') return;
-
+  const handleStatusClick = () => {
     updateMilestoneStatus(dispatch, {
       id: milestone.id,
-      status: 1
+      status: milestone.status === 'open' ? 1 : 0
     });
 
     history.push('/milestone');
@@ -93,7 +91,9 @@ function EditMilestone() {
       </IS.InputWrapper>
       <S.ButtonWrapper>
         <S.CancelButton onClick={() => history.push('/milestone')}>Cancel</S.CancelButton>
-        <S.CancelButton onClick={handleCloseClick}>Close milestone</S.CancelButton>
+        <S.CancelButton onClick={handleStatusClick}>
+          {milestone.status === 'open' ? 'Close' : 'Open'} milestone
+        </S.CancelButton>
         <BS.NewIssueButton onClick={handleSaveClick}>Save Changes</BS.NewIssueButton>
       </S.ButtonWrapper>
     </S.EditMilestoneWrapper>

--- a/client/src/components/editMilestone/index.js
+++ b/client/src/components/editMilestone/index.js
@@ -1,0 +1,38 @@
+import React, { useState, useEffect } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import BS from '@components/issues/header/buttons/style';
+import Input from '@components/newMilestone/input';
+import { TagIcon, MilestoneIcon } from '@primer/octicons-react';
+import MS from '@components/milestones/header/style';
+import S from './style';
+
+function EditMilestone() {
+  const history = useHistory();
+  const location = useLocation();
+  const { milestone } = location.state;
+
+  return (
+    <S.EditMilestoneWrapper>
+      <S.Header>
+        <MS.LabelMilestone>
+          <MS.LabelsButton onClick={() => history.push('/label')}>
+            <TagIcon size={14} />
+            <MS.ButtonText>Labels</MS.ButtonText>
+          </MS.LabelsButton>
+          <MS.MilestonesButton onClick={() => history.push('/milestone')}>
+            <MilestoneIcon />
+            <MS.ButtonText>Milestones</MS.ButtonText>
+          </MS.MilestonesButton>
+        </MS.LabelMilestone>
+      </S.Header>
+      <Input />
+      <S.ButtonWrapper>
+        <S.CancelButton>Cancel</S.CancelButton>
+        <S.CancelButton>Close milestone</S.CancelButton>
+        <BS.NewIssueButton>Create milestone</BS.NewIssueButton>
+      </S.ButtonWrapper>
+    </S.EditMilestoneWrapper>
+  );
+}
+
+export default EditMilestone;

--- a/client/src/components/editMilestone/index.js
+++ b/client/src/components/editMilestone/index.js
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import { useMilestonesDispatch, updateMilestone } from '@contexts/MilestonesContext';
+import {
+  useMilestonesDispatch,
+  updateMilestone,
+  updateMilestoneStatus
+} from '@contexts/MilestonesContext';
 import { TagIcon, MilestoneIcon } from '@primer/octicons-react';
 import BS from '@components/issues/header/buttons/style';
 import IS from '@components/newMilestone/input/style';
@@ -25,7 +29,14 @@ function EditMilestone() {
   };
 
   const handleCloseClick = () => {
-    /** @todo close버튼 클릭하면 마일스톤 status를 close로 업데이트 */
+    if (milestone.status === 'closed') return;
+
+    updateMilestoneStatus(dispatch, {
+      id: milestone.id,
+      status: 1
+    });
+
+    history.push('/milestone');
   };
 
   const handleSaveClick = () => {

--- a/client/src/components/editMilestone/index.js
+++ b/client/src/components/editMilestone/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import BS from '@components/issues/header/buttons/style';
 import Input from '@components/newMilestone/input';
@@ -14,7 +14,7 @@ function EditMilestone() {
   return (
     <S.EditMilestoneWrapper>
       <S.Header>
-        <MS.LabelMilestone>
+        <S.LabelMilestone>
           <MS.LabelsButton onClick={() => history.push('/label')}>
             <TagIcon size={14} />
             <MS.ButtonText>Labels</MS.ButtonText>
@@ -23,7 +23,7 @@ function EditMilestone() {
             <MilestoneIcon />
             <MS.ButtonText>Milestones</MS.ButtonText>
           </MS.MilestonesButton>
-        </MS.LabelMilestone>
+        </S.LabelMilestone>
       </S.Header>
       <Input />
       <S.ButtonWrapper>

--- a/client/src/components/editMilestone/index.js
+++ b/client/src/components/editMilestone/index.js
@@ -6,7 +6,6 @@ import {
   updateMilestoneStatus
 } from '@contexts/MilestonesContext';
 import { TagIcon, MilestoneIcon } from '@primer/octicons-react';
-import BS from '@components/issues/header/buttons/style';
 import IS from '@components/newMilestone/input/style';
 import MS from '@components/milestones/header/style';
 import S from './style';
@@ -94,7 +93,10 @@ function EditMilestone() {
         <S.CancelButton onClick={handleStatusClick}>
           {milestone.status === 'open' ? 'Close' : 'Open'} milestone
         </S.CancelButton>
-        <BS.NewIssueButton onClick={handleSaveClick}>Save Changes</BS.NewIssueButton>
+        <S.SubmitButton
+          isValid={title.length > 0 ? true : false}
+          onClick={handleSaveClick}
+        >Save Changes</S.SubmitButton>
       </S.ButtonWrapper>
     </S.EditMilestoneWrapper>
   );

--- a/client/src/components/editMilestone/style.js
+++ b/client/src/components/editMilestone/style.js
@@ -19,7 +19,7 @@ export default {
     display: flex;
     float: right;
     margin-top: 15px;
-    button{
+    button {
       height : 35px;
       padding : 0 18px;
       border-radius: 4px;
@@ -27,19 +27,21 @@ export default {
       white-space : nowrap;
       cursor : pointer;
     }
-    button:hover{
+    button:hover {
       filter : brightness(95%);
     }
   `,
   CancelButton: styled.button`
     border: 1px solid #e0e0e0;
     background: linear-gradient( to bottom, white, #eaeaea );
-    font-weight: bold;
     color : #5E656E;
-    border-radius: 4px;
-    padding: 5px 15px;
-    color: #000;
     margin-right: 8px;
-    cursor: pointer;
   `,
+  SubmitButton: styled.button`
+    border: 1px solid #329246;
+    background: linear-gradient(to bottom, #32cd56, #27a844);
+    color: #fff;
+    opacity : ${(props) => props.isValid ? '100%' : '60%'};
+    ${(props) => !props.isValid && 'pointer-events: none;'}
+  `
 };

--- a/client/src/components/editMilestone/style.js
+++ b/client/src/components/editMilestone/style.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export default {
+  EditMilestoneWrapper: styled.div`
+    margin: 24px auto;
+    max-width: 950px;
+  `,
+  Header: styled.div`
+    border-bottom: 1px solid #eaecef;
+  `,
+  ButtonWrapper: styled.div`
+  `,
+  CancelButton: styled.button`
+    border: 1px solid #e0e0e0;
+    background: linear-gradient( to bottom, white, #eaeaea );
+    color : #5E656E;
+    margin-right : 8px;
+  `,
+};

--- a/client/src/components/editMilestone/style.js
+++ b/client/src/components/editMilestone/style.js
@@ -8,12 +8,38 @@ export default {
   Header: styled.div`
     border-bottom: 1px solid #eaecef;
   `,
+  LabelMilestone: styled.div`
+    display: flex;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    width: fit-content;
+    margin-bottom: 15px;
+  `,
   ButtonWrapper: styled.div`
+    display: flex;
+    float: right;
+    margin-top: 15px;
+    button{
+      height : 35px;
+      padding : 0 18px;
+      border-radius: 4px;
+      font-weight : 600;
+      white-space : nowrap;
+      cursor : pointer;
+    }
+    button:hover{
+      filter : brightness(95%);
+    }
   `,
   CancelButton: styled.button`
     border: 1px solid #e0e0e0;
     background: linear-gradient( to bottom, white, #eaeaea );
+    font-weight: bold;
     color : #5E656E;
-    margin-right : 8px;
+    border-radius: 4px;
+    padding: 5px 15px;
+    color: #000;
+    margin-right: 8px;
+    cursor: pointer;
   `,
 };

--- a/client/src/components/milestones/Header/index.js
+++ b/client/src/components/milestones/Header/index.js
@@ -18,7 +18,7 @@ function Header() {
           <S.ButtonText>Milestones</S.ButtonText>
         </S.MilestonesButton>
       </S.LabelMilestone>
-      <S.NewMilestoneButton onClick={() => history.push('/newMilestone')}>New Milestone</S.NewMilestoneButton>
+      <S.NewMilestoneButton onClick={() => history.push('/milestone/new')}>New Milestone</S.NewMilestoneButton>
     </S.MilestoneHeader>
   );
 }

--- a/client/src/components/milestones/List/Milestone/index.js
+++ b/client/src/components/milestones/List/Milestone/index.js
@@ -43,7 +43,7 @@ function Milestone({ milestone, handleStatusClick, handleDeleteClick }) {
           <S.Button onClick={() => handleStatusClick(milestone.id, milestone.status)}>{
             milestone.status === 'open' ? 'Close' : 'Open'
           }</S.Button>
-          <S.Button className='delete-btn' onClick={handleDeleteClick}>Delete</S.Button>
+          <S.Button className='delete-btn' onClick={() => handleDeleteClick(milestone.id)}>Delete</S.Button>
         </S.ButtonWrapper>
       </S.Right>
     </S.MilestoneWrapper>

--- a/client/src/components/milestones/List/Milestone/index.js
+++ b/client/src/components/milestones/List/Milestone/index.js
@@ -4,9 +4,9 @@ import Date from '@utils/date';
 import { CalendarIcon } from '@primer/octicons-react';
 import S from './style';
 
-function Milestone({ milestone }) {
-  console.log('milestone.due_date :>> ', milestone.due_date);
+function Milestone({ milestone, handleStatusClick, handleDeleteClick }) {
   const history = useHistory();
+
   const openIssueCnt = milestone.issues.filter(issue => issue.status === 0).length;
   const closeIssueCnt = milestone.issues.filter(issue => issue.status === 1).length;
 
@@ -40,8 +40,10 @@ function Milestone({ milestone }) {
         </S.ProgressState>
         <S.ButtonWrapper>
           <S.Button onClick={handleEditClick}>Edit</S.Button>
-          <S.Button>Close</S.Button>
-          <S.Button className='delete-btn'>Delete</S.Button>
+          <S.Button onClick={() => handleStatusClick(milestone.id, milestone.status)}>{
+            milestone.status === 'open' ? 'Close' : 'Open'
+          }</S.Button>
+          <S.Button className='delete-btn' onClick={handleDeleteClick}>Delete</S.Button>
         </S.ButtonWrapper>
       </S.Right>
     </S.MilestoneWrapper>

--- a/client/src/components/milestones/List/Milestone/index.js
+++ b/client/src/components/milestones/List/Milestone/index.js
@@ -1,11 +1,20 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import Date from '@utils/date';
 import { CalendarIcon } from '@primer/octicons-react';
 import S from './style';
 
 function Milestone({ milestone }) {
+  const history = useHistory();
   const openIssueCnt = milestone.issues.filter(issue => issue.status === 0).length;
   const closeIssueCnt = milestone.issues.filter(issue => issue.status === 1).length;
+
+  const handleEditClick = () => {
+    history.push({
+      pathname: `/milestone/edit/${milestone.id}`,
+      state: { milestone }
+    });
+  };
 
   return (
     <S.MilestoneWrapper>
@@ -25,7 +34,7 @@ function Milestone({ milestone }) {
           <S.State>{closeIssueCnt} closed</S.State>
         </S.ProgressState>
         <S.ButtonWrapper>
-          <S.Button>Edit</S.Button>
+          <S.Button onClick={handleEditClick}>Edit</S.Button>
           <S.Button>Close</S.Button>
           <S.Button className='delete-btn'>Delete</S.Button>
         </S.ButtonWrapper>

--- a/client/src/components/milestones/List/Milestone/index.js
+++ b/client/src/components/milestones/List/Milestone/index.js
@@ -5,6 +5,7 @@ import { CalendarIcon } from '@primer/octicons-react';
 import S from './style';
 
 function Milestone({ milestone }) {
+  console.log('milestone.due_date :>> ', milestone.due_date);
   const history = useHistory();
   const openIssueCnt = milestone.issues.filter(issue => issue.status === 0).length;
   const closeIssueCnt = milestone.issues.filter(issue => issue.status === 1).length;
@@ -22,7 +23,11 @@ function Milestone({ milestone }) {
         <S.Title>{milestone.title}</S.Title>
         <S.DateWrapper>
           <CalendarIcon />
-          <S.Date>Due by {Date.getDate(milestone.due_date, { day: 'numeric', year: 'numeric', month: 'long' })}</S.Date>
+          <S.Date>{
+            milestone.due_date
+              ? 'Due by ' + Date.getDate(milestone.due_date, { day: 'numeric', year: 'numeric', month: 'long' })
+              : 'No due date'
+          }</S.Date>
         </S.DateWrapper>
         <S.Description>{milestone.desc}</S.Description>
       </S.Left>

--- a/client/src/components/milestones/List/index.js
+++ b/client/src/components/milestones/List/index.js
@@ -3,6 +3,7 @@ import {
   useMilestonesState,
   useMilestonesDispatch,
   getMilestones,
+  updateMilestoneStatus,
 } from '@contexts/MilestonesContext';
 import Milestone from './Milestone';
 import { MilestoneIcon, CheckIcon } from '@primer/octicons-react';
@@ -10,16 +11,24 @@ import Spinner from '@images/spinner3.gif';
 import S from './style';
 
 function List() {
-  const [status, setStatus] = useState(0); // open: 0, close: 1
   const state = useMilestonesState();
   const dispatch = useMilestonesDispatch();
   const { data, loading, error } = state.milestones;
+  const [status, setStatus] = useState(0); // open: 0, close: 1
+
+  useEffect(() => {
+    toggleStatus();
+  });
+
+  useEffect(() => {
+    fetchData();
+  }, [dispatch]);
 
   const fetchData = () => {
     getMilestones(dispatch);
   };
 
-  const handleStatus = (e, status) => {
+  const handleStatus = (status) => {
     setStatus(status);
   };
 
@@ -35,13 +44,18 @@ function List() {
     status === 0 ? $open.classList.add('show') : $close.classList.add('show');
   };
 
-  useEffect(() => {
-    toggleStatus();
-  });
+  const handleStatusClick = (id, status) => {
+    updateMilestoneStatus(dispatch, {
+      id,
+      status: status === 'open' ? 1 : 0
+    });
 
-  useEffect(() => {
     fetchData();
-  }, [dispatch, status]);
+  };
+
+  const handleDeleteClick = () => {
+
+  };
 
   if (loading) return <S.LoadSpinner src={Spinner} />;
   if (error) return <div>에러가 발생했습니다</div>;
@@ -53,11 +67,11 @@ function List() {
   return (
     <S.ListWrapper>
       <S.ListHeader>
-        <S.CountWrapper className='count-wrapper open' onClick={(e) => handleStatus(e, 0)}>
+        <S.CountWrapper className='count-wrapper open' onClick={() => handleStatus(0)}>
           <MilestoneIcon />
           <S.Count>{openCnt} Open</S.Count>
         </S.CountWrapper>
-        <S.CountWrapper className='count-wrapper close' onClick={(e) => handleStatus(e, 1)}>
+        <S.CountWrapper className='count-wrapper close' onClick={() => handleStatus(1)}>
           <CheckIcon />
           <S.Count>{closedCnt} Closed</S.Count>
         </S.CountWrapper>
@@ -66,7 +80,12 @@ function List() {
         {milestones && milestones.map(milestone => {
           const milestoneStatus = milestone.status === 'open' ? 0 : 1;
           if (milestoneStatus === status) {
-            return <Milestone key={milestone.id} milestone={milestone} />
+            return <Milestone
+              key={milestone.id}
+              milestone={milestone}
+              handleStatusClick={handleStatusClick}
+              handleDeleteClick={handleDeleteClick}
+            />
           }
         })}
       </S.List>

--- a/client/src/components/milestones/List/index.js
+++ b/client/src/components/milestones/List/index.js
@@ -14,6 +14,7 @@ function List() {
   const state = useMilestonesState();
   const dispatch = useMilestonesDispatch();
   const { data, loading, error } = state.milestones;
+  console.log('data :>> ', data);
 
   const fetchData = () => {
     getMilestones(dispatch);

--- a/client/src/components/milestones/List/index.js
+++ b/client/src/components/milestones/List/index.js
@@ -4,6 +4,7 @@ import {
   useMilestonesDispatch,
   getMilestones,
   updateMilestoneStatus,
+  deleteMilestone
 } from '@contexts/MilestonesContext';
 import Milestone from './Milestone';
 import { MilestoneIcon, CheckIcon } from '@primer/octicons-react';
@@ -53,8 +54,9 @@ function List() {
     fetchData();
   };
 
-  const handleDeleteClick = () => {
-
+  const handleDeleteClick = (id) => {
+    deleteMilestone(dispatch, { id });
+    fetchData();
   };
 
   if (loading) return <S.LoadSpinner src={Spinner} />;

--- a/client/src/components/milestones/List/index.js
+++ b/client/src/components/milestones/List/index.js
@@ -14,7 +14,6 @@ function List() {
   const state = useMilestonesState();
   const dispatch = useMilestonesDispatch();
   const { data, loading, error } = state.milestones;
-  console.log('data :>> ', data);
 
   const fetchData = () => {
     getMilestones(dispatch);

--- a/client/src/components/newMilestone/index.js
+++ b/client/src/components/newMilestone/index.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useMilestonesDispatch, createMilestone } from '@contexts/MilestonesContext';
-import BS from '@components/issues/header/buttons/style';
 import Input from './input';
 import S from './style';
 
@@ -46,7 +45,10 @@ function NewMilestone() {
       <Input handleTitle={handleTitle} handleDescription={handleDescription} />
       <S.ButtonWrapper>
         <S.CancelButton onClick={() => history.push('/milestone')}>Cancel</S.CancelButton>
-        <BS.NewIssueButton onClick={handleClick}>Create milestone</BS.NewIssueButton>
+        <S.SubmitButton
+          isValid={title.length > 0 ? true : false}
+          onClick={handleClick}
+        >Create milestone</S.SubmitButton>
       </S.ButtonWrapper>
     </S.NewMilestoneWrapper>
   );

--- a/client/src/components/newMilestone/index.js
+++ b/client/src/components/newMilestone/index.js
@@ -45,6 +45,7 @@ function NewMilestone() {
       </S.Header>
       <Input handleTitle={handleTitle} handleDescription={handleDescription} />
       <S.ButtonWrapper>
+        <S.CancelButton onClick={() => history.push('/milestone')}>Cancel</S.CancelButton>
         <BS.NewIssueButton onClick={handleClick}>Create milestone</BS.NewIssueButton>
       </S.ButtonWrapper>
     </S.NewMilestoneWrapper>

--- a/client/src/components/newMilestone/index.js
+++ b/client/src/components/newMilestone/index.js
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
-import { useMilestonesDispatch } from '@contexts/MilestonesContext';
+import { useHistory } from 'react-router-dom';
+import { useMilestonesDispatch, createMilestone } from '@contexts/MilestonesContext';
 import BS from '@components/issues/header/buttons/style';
 import Input from './input';
 import S from './style';
 
 function NewMilestone() {
+  const history = useHistory();
   const dispatch = useMilestonesDispatch();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -18,7 +20,18 @@ function NewMilestone() {
   };
 
   const handleClick = () => {
-    /** @todo POST milestone */
+    const inputDate = document.querySelector('.input-date').value;
+
+    if (title.length === 0) return;
+
+    createMilestone(dispatch, {
+      status: 0,
+      title,
+      due_date: inputDate,
+      desc: description
+    });
+
+    history.push('/milestone');
   };
 
   return (

--- a/client/src/components/newMilestone/input/index.js
+++ b/client/src/components/newMilestone/input/index.js
@@ -7,7 +7,7 @@ function Input({ handleTitle, handleDescription }) {
       <S.Title>Title</S.Title>
       <S.InputTitle className='form-control' placeholder='Title' onChange={handleTitle} />
       <S.Title>Due Date (optional)</S.Title>
-      <S.InputDate className='form-control' type='date' />
+      <S.InputDate className='form-control input-date' type='date' />
       <S.Title>Description (optional)</S.Title>
       <S.InputDescription className='form-control' onChange={handleDescription} />
     </S.InputWrapper>

--- a/client/src/components/newMilestone/style.js
+++ b/client/src/components/newMilestone/style.js
@@ -15,7 +15,22 @@ export default {
     margin-bottom: 16px;
   `,
   ButtonWrapper: styled.div`
+    display: flex;
     margin-top: 15px;
     float: right;
+  `,
+  CancelButton: styled.button`
+    border: 1px solid #e0e0e0;
+    background: linear-gradient( to bottom, white, #eaeaea );
+    font-weight: bold;
+    color : #5E656E;
+    border-radius: 4px;
+    padding: 5px 15px;
+    color: #000;
+    margin-right: 8px;
+    cursor: pointer;
+    &:hover{
+      filter : brightness(95%);
+    }
   `
 };

--- a/client/src/components/newMilestone/style.js
+++ b/client/src/components/newMilestone/style.js
@@ -18,19 +18,29 @@ export default {
     display: flex;
     margin-top: 15px;
     float: right;
+    button {
+      height : 35px;
+      padding : 0 18px;
+      border-radius: 4px;
+      font-weight : 600;
+      white-space : nowrap;
+      cursor : pointer;
+    }
+    button:hover {
+      filter : brightness(95%);
+    }
   `,
   CancelButton: styled.button`
     border: 1px solid #e0e0e0;
     background: linear-gradient( to bottom, white, #eaeaea );
-    font-weight: bold;
     color : #5E656E;
-    border-radius: 4px;
-    padding: 5px 15px;
-    color: #000;
     margin-right: 8px;
-    cursor: pointer;
-    &:hover{
-      filter : brightness(95%);
-    }
+  `,
+  SubmitButton: styled.button`
+    border: 1px solid #329246;
+    background: linear-gradient(to bottom, #32cd56, #27a844);
+    color: #fff;
+    opacity : ${(props) => props.isValid ? '100%' : '60%'};
+    ${(props) => !props.isValid && 'pointer-events: none;'}
   `
 };

--- a/client/src/contexts/MilestonesContext.js
+++ b/client/src/contexts/MilestonesContext.js
@@ -102,10 +102,19 @@ async function createMilestone(dispatch, params) {
   }
 }
 
+async function updateMilestone(dispatch, params) {
+  try {
+    await api.updateMilestone(params);
+  } catch (e) {
+    dispatch({ type: 'PUT_MILESTONE_ERROR', error: e });
+  }
+}
+
 export {
   MilestonesProvider,
   useMilestonesState,
   useMilestonesDispatch,
   getMilestones,
   createMilestone,
+  updateMilestone,
 };

--- a/client/src/contexts/MilestonesContext.js
+++ b/client/src/contexts/MilestonesContext.js
@@ -118,6 +118,14 @@ async function updateMilestoneStatus(dispatch, params) {
   }
 }
 
+async function deleteMilestone(dispatch, params) {
+  try {
+    await api.deleteMilestone(params);
+  } catch (e) {
+    dispatch({ type: 'PUT_MILESTONE_STATUS_ERROR', error: e });
+  }
+}
+
 export {
   MilestonesProvider,
   useMilestonesState,
@@ -126,4 +134,5 @@ export {
   createMilestone,
   updateMilestone,
   updateMilestoneStatus,
+  deleteMilestone
 };

--- a/client/src/contexts/MilestonesContext.js
+++ b/client/src/contexts/MilestonesContext.js
@@ -110,6 +110,14 @@ async function updateMilestone(dispatch, params) {
   }
 }
 
+async function updateMilestoneStatus(dispatch, params) {
+  try {
+    await api.updateMilestoneStatus(params);
+  } catch (e) {
+    dispatch({ type: 'PUT_MILESTONE_STATUS_ERROR', error: e });
+  }
+}
+
 export {
   MilestonesProvider,
   useMilestonesState,
@@ -117,4 +125,5 @@ export {
   getMilestones,
   createMilestone,
   updateMilestone,
+  updateMilestoneStatus,
 };

--- a/client/src/contexts/MilestonesContext.js
+++ b/client/src/contexts/MilestonesContext.js
@@ -1,7 +1,6 @@
 import React, { useReducer, createContext, useContext } from 'react';
 import * as api from '@api/milestone';
 
-// MilestonesContext에서 사용할 기본 상태
 const initialState = {
   milestones: {
     loading: false,
@@ -10,21 +9,18 @@ const initialState = {
   },
 };
 
-// 로딩중일 때 바뀔 상태 객체
 const loadingState = {
   loading: true,
   data: null,
   error: null,
 };
 
-// 성공했을 때의 상태를 만들어주는 함수
 const success = (data) => ({
   loading: false,
   data,
   error: null,
 });
 
-// 실패했을 때의 상태를 만들어주는 함수
 const error = (err) => ({
   loading: true,
   data: null,
@@ -53,12 +49,10 @@ function milestoneReducer(state, action) {
   }
 }
 
-// state용 context와 dispatch용 context 따로 만들어주기
 const MilestonesStateContext = createContext(null);
 const MilestonesDispatchContext = createContext(null);
 
-// 위에서 선언한 두가지 context들의 provider로 감싸주는 컴포넌트
-export function MilestonesProvider({ children }) {
+function MilestonesProvider({ children }) {
   const [state, dispatch] = useReducer(milestoneReducer, initialState);
 
   return (
@@ -70,7 +64,7 @@ export function MilestonesProvider({ children }) {
   );
 }
 
-export function useMilestonesState() {
+function useMilestonesState() {
   const state = useContext(MilestonesStateContext);
 
   if (!state) {
@@ -79,7 +73,7 @@ export function useMilestonesState() {
   return state;
 }
 
-export function useMilestonesDispatch() {
+function useMilestonesDispatch() {
   const dispatch = useContext(MilestonesDispatchContext);
   if (!dispatch) {
     throw new Error('Cannot find MilestonesProvider!');
@@ -87,7 +81,7 @@ export function useMilestonesDispatch() {
   return dispatch;
 }
 
-export async function getMilestones(dispatch) {
+async function getMilestones(dispatch) {
   dispatch({ type: 'GET_MILESTONES' });
   try {
     const response = await api.getMilestones();
@@ -99,3 +93,19 @@ export async function getMilestones(dispatch) {
     dispatch({ type: 'GET_MILESTONES_ERROR', error: e });
   }
 }
+
+async function createMilestone(dispatch, params) {
+  try {
+    await api.createMilestone(params);
+  } catch (e) {
+    dispatch({ type: 'POST_MILESTONE_ERROR', error: e });
+  }
+}
+
+export {
+  MilestonesProvider,
+  useMilestonesState,
+  useMilestonesDispatch,
+  getMilestones,
+  createMilestone,
+};

--- a/client/src/contexts/MilestonesContext.js
+++ b/client/src/contexts/MilestonesContext.js
@@ -66,7 +66,6 @@ function MilestonesProvider({ children }) {
 
 function useMilestonesState() {
   const state = useContext(MilestonesStateContext);
-
   if (!state) {
     throw new Error('Cannot find MilestonesProvider!');
   }

--- a/client/src/pages/EditMilestonePage.js
+++ b/client/src/pages/EditMilestonePage.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Header from '@components/header';
+import EditMilestone from '@components/editMilestone';
+
+function EditMilestonePage() {
+  return (
+    <>
+      <Header />
+      <EditMilestone />
+    </>
+  );
+}
+
+export default EditMilestonePage;

--- a/server/services/milestone.js
+++ b/server/services/milestone.js
@@ -4,8 +4,9 @@ exports.getMilestones = async () => {
   const results = await db.selectMilestone();
   let milestoneCnt = [0, 0];
   const milestones = [];
+
   for (let result of results) {
-    let status = result.status === 0 ? 'open' : 'closed';
+    const status = result.status === 0 ? 'open' : 'closed';
     milestoneCnt[result.status] += 1;
     milestones.push({ ...result.dataValues, status });
   }
@@ -13,21 +14,21 @@ exports.getMilestones = async () => {
 };
 
 exports.findMilestone = async (title) => {
-  const results = await db.selectMilestoneID(title);
-  return results;
+  const result = await db.selectMilestoneID(title);
+  return result;
 };
 
 exports.createMilestone = async (params) => {
-  const results = await db.insertMilestone(params);
-  return results;
+  const result = await db.insertMilestone(params);
+  return result;
 };
 
 exports.updateMilestone = async (params) => {
-  const results = await db.updateMilestone(params);
-  return results;
+  const result = await db.updateMilestone(params);
+  return result;
 };
 
 exports.deleteMilestone = async (params) => {
-  const results = await db.deleteMilestone(params);
-  return results;
+  const result = await db.deleteMilestone(params);
+  return result;
 };


### PR DESCRIPTION
### 구현한 기능
> 마일스톤 목록 페이지
  - 마일스톤 목록의 각 마일스톤 컴포넌트에서 open/close 버튼 toggle 구현
  - edit, close/open, delete 버튼 이벤트 구현
  - 마일스톤 완료일 분기처리 -> 완료일이 없는 경우 No due date로 표시
> 마일스톤 생성 페이지
  - create milestone 버튼 이벤트 구현
  - ui 수정
    - submit 버튼 이벤트 발생 제한
    - cancel 버튼 추가
  - url 수정 (/newMilestone -> /milestone/new)
> 마일스톤 수정 페이지
  - ui 구현
    - submit 버튼 이벤트 발생 제한
    - open/close milestone 버튼 toggle 구현
  - milestone의 edit 버튼과 수정 페이지 연결 -> history.push할때 milestone을 props로 넘겨줌
  - cancel, close milestone, save changes 버튼 이벤트 구현